### PR TITLE
use params:delta to access all 16 ports

### DIFF
--- a/midi-monitor.lua
+++ b/midi-monitor.lua
@@ -282,7 +282,7 @@ end
 function enc(id,delta)
   if id == 1 then
     --print(params:get("midi_device"))
-    params:set("midi_device", util.clamp(devicepos+delta, 1,4))
+    params:delta("midi_device", delta)
     if clocking then
       clock.cancel(blink_id)
       clocking = false


### PR DESCRIPTION
such a useful script! just changed one line to utilize `params:delta` to change device focus, which allows all 16 reporting vports to be scrobbled through in the main UI <3